### PR TITLE
210412 📝 React.FC를 템플릿에서 제거한 이유 

### DIFF
--- a/210412.md
+++ b/210412.md
@@ -1,0 +1,138 @@
+---
+category: Typescript React
+title: Remove React.FC from Typescript template (facebook team)
+---
+<div align="center" style="margin-bottom: 5px;">
+    <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB"> 
+    <img src="https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white">
+</div>
+
+
+**이 글을 읽은 후**
+
+나는 대부분의 함수형 컴포넌트 선언에 React.FC를 사용하는데, 오늘 리뷰를 하다가 이 글에 대해서 알게되었다.
+
+대부분 알고 있던 사실이긴했는데, 사실 children에 관해서는 처음 알았다..😵
+(지금까지 React.FC를 쓰더라도 children을 명시해서 써왔음ㅋㅋㅋ..)
+
+그럼 대체 나는 왜 React.FC를 사용했던 것일까..라고 생각해보게 된 계기가 되었다.
+
+습관이란게 무서워서 이 글을 제대로 읽기 전인 오늘까지도 React.FC를 쓰고왔는데, 공용으로 쓰는 컴포넌트에서라도 안써야겠다.😞
+
+---
+
+> 이 글은 [Remove React.FC from Typescript template](https://github.com/facebook/create-react-app/pull/8177) PR Description을 번역한 글입니다. 
+
+이 PR은 Typescript 프로젝트의 기본 템플릿에서 `React.FC`를 제거합니다.
+
+작은 변화에 대한 긴 설명: 
+
+`React.FC`는 불필요합니다: 이것은 거의 혜택을 제공하지 않고, 몇가지 단점을 가지고 있습니다. (아래를 보세요.) 하지만 나는 많은 TS + React 초보자들이 이를 사용하는 걸 보았고, 이 템플릿에서 사용하는 것이 사실상 "Best Practice" 소스로서 기여했기 때문이라고 생각합니다.  
+
+### React.FC/React.FunctionComponent의 단점
+
+#### `children`에 대한 암시적 정의 제공
+
+`React.FC`로 컴포넌트를 정의하는 것은, 암시적으로 `ReactNode`타입의 `children`을 가져옵니다. 이것은 모든 컴포넌트가 children을 지원하지 않더라도, children을 받아들이는 걸 허용한다는 것이죠:
+
+```tsx
+const App: React.FC = () => {/*...*/};
+const Example = () => {
+    <App><div>Unwanted children</div></App>
+}
+```
+
+런타임 에러는 아니지만, 실수를 만들 수 있고, `React.FC`가 아니라면 Typescript에서 잡아낼 수 있는 오류입니다.
+
+#### Generic을 지원하지 않음
+
+아래와 같이 Generic 컴포넌트를 정의할 수 있습니다:
+
+```typescript
+type GenericComponentProps<T> = {
+    prop: T
+    callback: (t: T) => void
+}
+const GenericComponent = <T>(props: GenericComponentProps<T>) => {/*...*/}
+```
+
+하지만 이것은 `React.FC`를 사용할 경우 지원되지 않습니다. - `React.FC`에서 반환된 타입에서 resolve되지 않은 Generic T를 보존할 방법이 없습니다.
+
+```typescript
+const GenericComponent: React.FC</* ??? */> = <T>(props: GenericComponentProps<T>) => {/*...*/}
+```
+
+#### "Component as namespace pattern"을 어색하게 만듦
+
+컴포넌트를 관련 컴포넌트의 namespace로 사용하는 것(일반적으로는 자식)은 꽤 인기있는 패턴입니다:
+
+```jsx
+<Select>
+    <Select.Item />
+</Select>
+```
+
+이건 가능하긴 하지만, `React.FC`로 사용하면 좀 이상합니다:
+
+```tsx
+const Select: React.FC<SelectProps> & {Item: React.FC<ItemProps>} = (props) => {/*...*/}
+Select.Item = (props) => {/*...*/}
+```
+
+하지만 `React.FC`가 없으면 그냥 이렇게 만들 수 있죠:
+
+```tsx
+const Select = (props: SelectProps) => {/*...*/}
+Select.Item = (props: ItemProps) => {/*...*/}
+```
+
+#### defaultProps에서 올바르게 동작하지 않음
+
+이건 두 예시 모두 ES6 기본 인수를 사용하는게 더 낫기 때문에 상당히 논쟁의 여지가 있긴 하지만...
+
+```tsx
+type ComponentProps = {name: string;}
+
+const Component = ({name} : ComponentProps) => (<div>
+    {name.toUpperCase()} /* 이름이 필요하기 때문에 안전함 */
+    </div>);
+Component.defaultProps = {name: "John"};
+
+const Example = () => (<Component />) /* name이 default 값이 있기 때문에 생략되어 안전함 */
+```
+
+이것은 잘 컴파일 됩니다. `React.FC`를 사용한 모든 접근 방식은 약간 잘못될 것입니다: `React.FC<{name: string}>`는 이를 소비하는 consumers 컴포넌트들이 name을 필요한 prop으로 만듭니다. 만약 optional하게 필요한 경우 `React.FC<{name?: string}>`을 사용하면 이는 `name.toUpperCase()`에 타입 에러를 발생시키죠. 이 방법은 "내부적으로 필요하지만, 외부적으로는 optional한" 행동의 요구사항을 위와 같이 복제해낼 방법이 없습니다. 
+
+#### 다른 것들보다 길거나 더 길다: (`FunctionalComponent`를 사용할 경우 특히 더):
+
+요점은 아니긴 하지만, `React.FC`를 쓴다고해도 짧지 않습니다.
+
+```tsx
+const C1: React.FC<CProps> = (props) => {}
+const C2 = (props: CProps) => {}
+```
+
+### React.FC의 장점
+
+#### 명시적 반환을 제공
+
+제가 찾을 수 있는 `React.FC`의 유일한 장점은 (`children`을 암시적으로 포함한다는게 좋다고 생각하지 않는 이상) 아래와 같은 실수를 포착하는 반환 타입을 지정한다는 것입니다:
+
+```tsx
+const Component = () => {
+    return undefined; //컴포넌트는 undefined를 리턴하는 것을 허용하지 않음. `null`만 허용.
+}
+```
+
+하지만 사용하려고 하면 바로 잡히는 에러이기 때문에 괜찮다고 생각합니다:
+
+```tsx
+const Example = () => <Component />; // Component가 잘못된 걸 반환하고 있기 때문에 여기서 에러가 발생.
+```
+
+명시적 타입 annotation이더라도, `React.FC`는 여전히 boilerplate를 많이 절약하지 않습니다:
+
+```tsx
+const Component1 = (props: ComponentProps): JSX.Element => {/*...*/}
+const Component2: FC<ComponentProps> = (props) => {/*...*/}
+```


### PR DESCRIPTION
<div align="center" style="margin-bottom: 5px;">
    <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB"> 
    <img src="https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white">
</div>


**이 글을 읽은 후**

나는 대부분의 함수형 컴포넌트 선언에 React.FC를 사용하는데, 오늘 리뷰를 하다가 이 글에 대해서 알게되었다.

대부분 알고 있던 사실이긴했는데, 사실 children에 관해서는 처음 알았다..😵
(지금까지 React.FC를 쓰더라도 children을 명시해서 써왔음ㅋㅋㅋ..)

그럼 대체 나는 왜 React.FC를 사용했던 것일까..라고 생각해보게 된 계기가 되었다.

습관이란게 무서워서 이 글을 제대로 읽기 전인 오늘까지도 React.FC를 쓰고왔는데, 공용으로 쓰는 컴포넌트에서라도 안써야겠다.😞